### PR TITLE
Use wp_remote_get instead of file_get_contents for server compatibility

### DIFF
--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -845,13 +845,16 @@ class RT_Transcoder_Handler {
 							} catch ( Exception $e ) {
 								$flag = $e->getMessage();
 							}
-							if ( $file_bits ) {
+
+							$file_content = wp_remote_retrieve_body( $file_bits );
+
+							if ( ! empty( $file_content ) ) {
 
 								if ( 'wp-media' !== $job_for ) {
 									add_filter( 'upload_dir', array( $this, 'upload_dir' ) );
 								}
 
-								$upload_info = wp_upload_bits( $new_wp_attached_file_pathinfo['basename'], null, wp_remote_retrieve_body( $file_bits ) );
+								$upload_info = wp_upload_bits( $new_wp_attached_file_pathinfo['basename'], null, $file_content );
 
 								/**
 								 * Allow users to filter/perform action on uploaded transcoded file.

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -841,7 +841,7 @@ class RT_Transcoder_Handler {
 							$new_wp_attached_file_pathinfo 	= pathinfo( $download_url );
 							$post_mime_type                	= 'mp4' === $new_wp_attached_file_pathinfo['extension'] ? 'video/mp4' : 'audio/mp3';
 							try {
-								$file_bits = function_exists( 'wpcom_vip_file_get_contents' ) ? wpcom_vip_file_get_contents( $download_url ) : wp_remote_get( $download_url ); // @codingStandardsIgnoreLine
+								$file_bits = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $download_url ) : wp_remote_get( $download_url ); // @codingStandardsIgnoreLine
 							} catch ( Exception $e ) {
 								$flag = $e->getMessage();
 							}
@@ -851,7 +851,7 @@ class RT_Transcoder_Handler {
 									add_filter( 'upload_dir', array( $this, 'upload_dir' ) );
 								}
 
-								$upload_info = wp_upload_bits( $new_wp_attached_file_pathinfo['basename'], null, $file_bits['body'] );
+								$upload_info = wp_upload_bits( $new_wp_attached_file_pathinfo['basename'], null, wp_remote_retrieve_body( $file_bits ) );
 
 								/**
 								 * Allow users to filter/perform action on uploaded transcoded file.

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -841,7 +841,7 @@ class RT_Transcoder_Handler {
 							$new_wp_attached_file_pathinfo 	= pathinfo( $download_url );
 							$post_mime_type                	= 'mp4' === $new_wp_attached_file_pathinfo['extension'] ? 'video/mp4' : 'audio/mp3';
 							try {
-								$file_bits = function_exists( 'wpcom_vip_file_get_contents' ) ? wpcom_vip_file_get_contents( $download_url ) : file_get_contents( $download_url ); // @codingStandardsIgnoreLine
+								$file_bits = function_exists( 'wpcom_vip_file_get_contents' ) ? wpcom_vip_file_get_contents( $download_url ) : wp_remote_get( $download_url ); // @codingStandardsIgnoreLine
 							} catch ( Exception $e ) {
 								$flag = $e->getMessage();
 							}

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -841,12 +841,12 @@ class RT_Transcoder_Handler {
 							$new_wp_attached_file_pathinfo 	= pathinfo( $download_url );
 							$post_mime_type                	= 'mp4' === $new_wp_attached_file_pathinfo['extension'] ? 'video/mp4' : 'audio/mp3';
 							try {
-								$file_bits = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $download_url ) : wp_remote_get( $download_url ); // @codingStandardsIgnoreLine
+								$response = function_exists( 'vip_safe_wp_remote_get' ) ? vip_safe_wp_remote_get( $download_url ) : wp_remote_get( $download_url ); // @codingStandardsIgnoreLine
 							} catch ( Exception $e ) {
 								$flag = $e->getMessage();
 							}
 
-							$file_content = wp_remote_retrieve_body( $file_bits );
+							$file_content = wp_remote_retrieve_body( $response );
 
 							if ( ! empty( $file_content ) ) {
 

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -851,7 +851,7 @@ class RT_Transcoder_Handler {
 									add_filter( 'upload_dir', array( $this, 'upload_dir' ) );
 								}
 
-								$upload_info = wp_upload_bits( $new_wp_attached_file_pathinfo['basename'], null, $file_bits );
+								$upload_info = wp_upload_bits( $new_wp_attached_file_pathinfo['basename'], null, $file_bits['body'] );
 
 								/**
 								 * Allow users to filter/perform action on uploaded transcoded file.


### PR DESCRIPTION
Use `wp_remote_get` instead of `file_get_contents` for server compatibility
Fixes #36 
