### PR TITLE
Add PHPCompatibility in installed_path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
 - pear install pear/PHP_CodeSniffer
 - git clone git://github.com/wimg/PHPCompatibility.git $(pear config-get php_dir)/PHP/CodeSniffer/Standards/PHPCompatibility
 - phpenv rehash
+- phpcs --config-set installed_paths $(pear config-get php_dir)/PHP/CodeSniffer/Standards/PHPCompatibility
 - phpcs -i
 - phpenv rehash
 - phpcs --config-set error_severity 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_script:
 - pear install pear/PHP_CodeSniffer
 - git clone git://github.com/wimg/PHPCompatibility.git $(pear config-get php_dir)/PHP/CodeSniffer/Standards/PHPCompatibility
 - phpenv rehash
+- phpcs --config-set installed_paths $(pear config-get php_dir)/PHP/CodeSniffer/Standards
 - phpcs --config-set installed_paths $(pear config-get php_dir)/PHP/CodeSniffer/Standards/PHPCompatibility
 - phpcs -i
 - phpenv rehash

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 php:
 - 5.5
 before_script:
-- pear install pear/PHP_CodeSniffer
+- pear install pear/PHP_CodeSniffer-2.9.1
 - git clone git://github.com/wimg/PHPCompatibility.git $(pear config-get php_dir)/PHP/CodeSniffer/Standards/PHPCompatibility
 - phpenv rehash
 - phpcs --config-set installed_paths $(pear config-get php_dir)/PHP/CodeSniffer/Standards


### PR DESCRIPTION
Add `PHPCompatibility` in `installed_paths` because builds are failing as it doesn't get the path to the `PHPCompatibility`.