### PR TITLE
Remove mp4 video job type condition

### DIFF
--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -195,11 +195,6 @@ class RT_Transcoder_Handler {
 			}
 
 			$job_type = 'video';
-			/**  FORMAT * */
-			if ( 'video/mp4' === $metadata['mime_type'] && 'mp4' === $type ) {
-				$autoformat = 'thumbnails';
-				$job_type = 'thumbnail';
-			}
 
 			if ( 'audio' === $type_array[0] ) {
 				$job_type = 'audio';


### PR DESCRIPTION
Remove mp4 video job type condition to transcode mp4 video if the video is not x264 encoded.