### PR TITLE
Fix retranscode service and duplicate thumbnail issue

### DIFF
--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -512,7 +512,7 @@ class RetranscodeMedia {
 							'id'   => array(),
 						),
 					);
-					?>
+				?>
 
 				if ( rt_errors > 0 ) {
 					rt_resulttext = '<?php echo wp_kses( $text_failures, $allowed_tags ); ?>';

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -521,7 +521,11 @@ class RetranscodeMedia {
 				}
 				$("#message").html("<p><strong>" + rt_resulttext + "</strong></p>");
 				$("#message").show();
-				$( '#retranscode-goback' ).attr( 'href', 'javascript:history.go(-1)' );
+
+				$( '#retranscode-goback' ).on( 'click', function () {
+					window.history.go( -1 );
+				} );
+
 			}
 			<?php
 				// translators: Media ID.

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -504,11 +504,20 @@ class RetranscodeMedia {
 
 				$('#retranscodemedia-stop').hide();
 
+				<?php
+					// Allowed tags for notice.
+					$allowed_tags = array(
+						'a' => array(
+							'href' => array(),
+							'id'   => array(),
+						),
+					);
+					?>
+
 				if ( rt_errors > 0 ) {
-					rt_resulttext = '<?php echo wp_kses( $text_failures, array( 'a' => array( 'href' => array(), 'id' => array() ) ) ); ?>';
+					rt_resulttext = '<?php echo wp_kses( $text_failures, $allowed_tags ); ?>';
 				} else {
-					<?php error_log( $text_nofailures ); ?>
-					rt_resulttext = '<?php echo wp_kses( $text_nofailures, array( 'a' => array( 'href' => array(), 'id' => array() ) ), array( 'javascript' ) ); ?>';
+					rt_resulttext = '<?php echo wp_kses( $text_nofailures, $allowed_tags ); ?>';
 				}
 				$("#message").html("<p><strong>" + rt_resulttext + "</strong></p>");
 				$("#message").show();

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -318,7 +318,14 @@ class RetranscodeMedia {
 				}
 			} else {
 				add_filter( 'posts_where', array( $this, 'add_search_mime_types' ) );
-				$query = new WP_Query( array( 'post_type' => 'attachments' ) );
+
+				$query = new WP_Query(
+					array(
+						'post_type'      => 'attachments',
+						'posts_per_page' => -1,
+						'post_status'    => 'any',
+					)
+				);
 				$media = $query->get_posts();
 				remove_filter( 'posts_where', array( $this, 'add_search_mime_types' ) );
 				if ( empty( $media ) || is_wp_error( $media ) ) {

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -318,14 +318,7 @@ class RetranscodeMedia {
 				}
 			} else {
 				add_filter( 'posts_where', array( $this, 'add_search_mime_types' ) );
-
-				$query = new WP_Query(
-					array(
-						'post_type'      => 'attachments',
-						'posts_per_page' => -1,
-						'post_status'    => 'any',
-					)
-				);
+				$query = new WP_Query( array( 'post_type' => 'attachments' ) );
 				$media = $query->get_posts();
 				remove_filter( 'posts_where', array( $this, 'add_search_mime_types' ) );
 				if ( empty( $media ) || is_wp_error( $media ) ) {

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -849,10 +849,6 @@ class RetranscodeMedia {
 				wp_update_attachment_metadata( $media_id, $attach_data );
 			} else {
 				// Insert transcoded thumbnail attachment for video/audio files.
-				$existing_thumbnail = get_post_thumbnail_id( $media_id );
-				if ( ! empty( $existing_thumbnail ) ) {
-					wp_delete_attachment( $existing_thumbnail, true );
-				}
 				$attachment_id = wp_insert_attachment( $attachment, $thumbnail_src, $media_id );
 			}
 

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -408,7 +408,7 @@ class RetranscodeMedia {
 
 
 			// translators: Count of media which were successfully transcoded with the time in seconds.
-			$text_goback = ( ! empty( $_GET['goback'] ) ) ? sprintf( __( 'To go back to the previous page, <a href="%s">click here</a>.', 'transcoder' ), 'javascript:history.go(-1)' ) : '';
+			$text_goback = ( ! empty( $_GET['goback'] ) ) ? __( 'To go back to the previous page, <a id="retranscode-goback" href="#">click here</a>.', 'transcoder' ) : '';
 
 			// translators: Count of media which were successfully and media which were failed transcoded with the time in seconds and previout page link.
 			$text_failures = sprintf( __( 'All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were %3$s failure(s). To try transcoding the failed media again, <a href="%4$s">click here</a>. %5$s', 'transcoder' ), "' + rt_successes + '", "' + rt_totaltime + '", "' + rt_errors + '", esc_url( wp_nonce_url( admin_url( 'admin.php?page=rt-retranscoder&goback=1' ), 'rt-retranscoder' ) . '&ids=' ) . "' + rt_failedlist + '", $text_goback );
@@ -505,13 +505,14 @@ class RetranscodeMedia {
 				$('#retranscodemedia-stop').hide();
 
 				if ( rt_errors > 0 ) {
-					rt_resulttext = '<?php echo wp_kses( $text_failures, array( 'a' => array( 'href' => array() ) ) ); ?>';
+					rt_resulttext = '<?php echo wp_kses( $text_failures, array( 'a' => array( 'href' => array(), 'id' => array() ) ) ); ?>';
 				} else {
-					rt_resulttext = '<?php echo esc_html( $text_nofailures ); ?>';
+					<?php error_log( $text_nofailures ); ?>
+					rt_resulttext = '<?php echo wp_kses( $text_nofailures, array( 'a' => array( 'href' => array(), 'id' => array() ) ), array( 'javascript' ) ); ?>';
 				}
-
 				$("#message").html("<p><strong>" + rt_resulttext + "</strong></p>");
 				$("#message").show();
+				$( '#retranscode-goback' ).attr( 'href', 'javascript:history.go(-1)' );
 			}
 			<?php
 				// translators: Media ID.

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -849,6 +849,10 @@ class RetranscodeMedia {
 				wp_update_attachment_metadata( $media_id, $attach_data );
 			} else {
 				// Insert transcoded thumbnail attachment for video/audio files.
+				$existing_thumbnail = get_post_thumbnail_id( $media_id );
+				if ( ! empty( $existing_thumbnail ) ) {
+					wp_delete_attachment( $existing_thumbnail, true );
+				}
 				$attachment_id = wp_insert_attachment( $attachment, $thumbnail_src, $media_id );
 			}
 

--- a/admin/rt-retranscode-admin.php
+++ b/admin/rt-retranscode-admin.php
@@ -301,8 +301,7 @@ class RetranscodeMedia {
 
 			// Create the list of image IDs.
 			$usage_info = get_site_option( 'rt-transcoding-usage' );
-			$ids        = transcoder_filter_input( INPUT_REQUEST, 'ids', FILTER_SANITIZE_NUMBER_INT, FILTER_REQUIRE_ARRAY );
-
+			$ids        = filter_input( INPUT_GET, 'ids', FILTER_SANITIZE_STRING );
 			if ( ! empty( $ids ) ) {
 				if ( is_array( $ids ) ) {
 					$ids = implode( ',', $ids );
@@ -417,7 +416,7 @@ class RetranscodeMedia {
 			// translators: Count of media which were successfully and media which were failed transcoded with the time in seconds and previout page link.
 			$text_failures = sprintf( __( 'All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were %3$s failure(s). To try transcoding the failed media again, <a href="%4$s">click here</a>. %5$s', 'transcoder' ), "' + rt_successes + '", "' + rt_totaltime + '", "' + rt_errors + '", esc_url( wp_nonce_url( admin_url( 'admin.php?page=rt-retranscoder&goback=1' ), 'rt-retranscoder' ) . '&ids=' ) . "' + rt_failedlist + '", $text_goback );
 			// translators: Count of media which were successfully transcoded with the time in seconds and previout page link.
-			$text_nofailures = sprintf( __( 'All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were 0 failures. %3$s', 'transcoder' ), "' + rt_successes + '", "' + rt_totaltime + '", $text_goback );
+			$text_nofailures = sprintf( __( 'All done! %1$s media file(s) were successfully sent for transcoding in %2$s seconds and there were 0 failures. %3$s', 'transcoder' ), " + rt_successes + ", "' + rt_totaltime + '", $text_goback );
 			?>
 
 
@@ -528,12 +527,12 @@ class RetranscodeMedia {
 						if ( response !== Object( response ) || ( typeof response.success === "undefined" && typeof response.error === "undefined" ) ) {
 							response = new Object;
 							response.success = false;
-							response.error = "
+							response.error = `
 							<?php
 							// translators: Media ID.
 							printf( esc_js( __( 'The resize request was abnormally terminated (ID %s). This is likely due to the media exceeding available memory or some other type of fatal error.', 'transcoder' ) ), '" + id + "' );
 							?>
-							";
+							`;
 						}
 
 						if ( response.success ) {
@@ -607,8 +606,7 @@ class RetranscodeMedia {
 	public function ajax_process_retranscode_request() {
 
 		header( 'Content-type: application/json' );
-
-		$id = transcoder_filter_input( INPUT_REQUEST, 'id', FILTER_SANITIZE_NUMBER_INT );
+		$id = filter_input( INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT );
 		$id = intval( $id );
 
 		if ( empty( $id ) || 0 >= $id ) {
@@ -620,7 +618,7 @@ class RetranscodeMedia {
 		if ( ! $media || 'attachment' !== $media->post_type ||
 			(
 				'audio/' !== substr( $media->post_mime_type, 0, 6 ) &&
-				'video/' !== substr( $media->post_mime_type, 0, 6 ) ||
+				'video/' !== substr( $media->post_mime_type, 0, 6 ) &&
 				'application/pdf' !== $media->post_mime_type
 			)
 		) {

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -1510,6 +1510,9 @@ class RT_Transcoder_Handler {
 				$results              = $wpdb->get_results( $wpdb->prepare( 'SELECT id FROM %s WHERE media_id = %d', $wpdb->prefix . 'rt_rtm_media', $post_id ), OBJECT ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 				$response['media_id'] = $results[0]->id;
 
+			} elseif ( ! empty( $status_info ) && 'processed' === $status_info->status && ( 'pdf' === $status_info->job_type ) ) {
+				$message = $messages['success'];
+				$status  = 'Success';
 			} elseif ( ! empty( $status_info ) ) {
 				$message = $status_info->status;
 			}

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -1603,7 +1603,6 @@ class RT_Transcoder_Handler {
 
 		$post_array['thumbnail'] = array();
 		if ( ! empty( $post_var['thumbnail'] ) && is_array( $post_var['thumbnail'] ) ) {
-			$post_array['thumbnail'] = filter_var( $post_var['thumbnail'], FILTER_SANITIZE_URL, FILTER_FORCE_ARRAY );
 			foreach ( $post_var['thumbnail'] as $thumbnail_url ) {
 				$post_array['thumbnail'][] = filter_var( $thumbnail_url, FILTER_SANITIZE_URL );
 			}

--- a/admin/rt-transcoder-handler.php
+++ b/admin/rt-transcoder-handler.php
@@ -29,7 +29,7 @@ class RT_Transcoder_Handler {
 	 * @access   protected
 	 * @var      string    $transcoding_api_url    The URL of the api.
 	 */
-	protected $transcoding_api_url = 'http://api.rtmedia.io/api/v1/';
+	protected $transcoding_api_url = 'https://api.rtmedia.io/api/v1/';
 
 	/**
 	 * The URL of the EDD store.


### PR DESCRIPTION
Issue: #164 

- Fix values of `$_GET['ids']`  sanitization to get the values of ids as comma-separated.
- Fix condition to check the mime-types of allowed media.
- Fix admin notice string sanitization
- Fix duplicate thumbnail issue for video file
- Update transcoder server URL protocol to `https`